### PR TITLE
Combined dependency updates (2025-10-05)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,6 +55,6 @@ jobs:
       - name: Download coverage reports
         uses: actions/download-artifact@v5
       - name: SonarQubeScan
-        uses: SonarSource/sonarqube-scan-action@v6
+        uses: SonarSource/sonarqube-scan-action@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602 # V.6.0 lastest 05/10/2025
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,6 +55,6 @@ jobs:
       - name: Download coverage reports
         uses: actions/download-artifact@v5
       - name: SonarQubeScan
-        uses: SonarSource/sonarqube-scan-action@v5
+        uses: SonarSource/sonarqube-scan-action@v6
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "2024.0.0"
 dependencies = [
     "setuptools==80.9.0",
     "pytest==8.4.1",
-    "pytest-cov==6.2.1",
+    "pytest-cov==7.0.0",
     "flake8== 7.3.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "samples-python-template"
 version = "2024.0.0"
 dependencies = [
     "setuptools==80.9.0",
-    "pytest==8.4.1",
+    "pytest==8.4.2",
     "pytest-cov==6.2.1",
     "flake8== 7.3.0",
 ]


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump pytest-cov from 6.2.1 to 7.0.0](https://github.com/augustocristian/samples-python-template/pull/21)
- [Bump pytest from 8.4.1 to 8.4.2](https://github.com/augustocristian/samples-python-template/pull/20)
- [Bump SonarSource/sonarqube-scan-action from 5 to 6](https://github.com/augustocristian/samples-python-template/pull/19)
- [Bump actions/setup-python from 5 to 6](https://github.com/augustocristian/samples-python-template/pull/18)