### PR TITLE
Combined dependency updates (2025-12-08)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     name: "Build & test"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Set up Python 3.12
         uses: actions/setup-python@v6
         with:
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Download coverage reports

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "samples-python-template"
 version = "2024.0.0"
 dependencies = [
     "setuptools==80.9.0",
-    "pytest==8.4.2",
+    "pytest==9.0.1",
     "pytest-cov==7.0.0",
     "flake8== 7.3.0",
 ]


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump pytest from 8.4.2 to 9.0.1](https://github.com/augustocristian/samples-python-template/pull/27)
- [Bump actions/checkout from 5 to 6](https://github.com/augustocristian/samples-python-template/pull/26)