### PR TITLE
Combined dependency updates (2026-01-04)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Download coverage reports
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
       - name: SonarQubeScan
         uses: SonarSource/sonarqube-scan-action@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602 # V.6.0 lastest 05/10/2025
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,6 +55,6 @@ jobs:
       - name: Download coverage reports
         uses: actions/download-artifact@v6
       - name: SonarQubeScan
-        uses: SonarSource/sonarqube-scan-action@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602 # V.6.0 lastest 05/10/2025
+        uses: SonarSource/sonarqube-scan-action@a31c9398be7ace6bbfaf30c0bd5d415f843d45e9 # V.6.0 lastest 05/10/2025
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,12 +35,12 @@ jobs:
         run: |
           pytest
       - name: Store coverage report
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: coverage-unit
           path: coverage.xml
       - name: Archive logs
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: test-logs
           path: logs/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "samples-python-template"
 version = "2024.0.0"
 dependencies = [
     "setuptools==80.9.0",
-    "pytest==9.0.1",
+    "pytest==9.0.2",
     "pytest-cov==7.0.0",
     "flake8== 7.3.0",
 ]


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump pytest from 9.0.1 to 9.0.2](https://github.com/augustocristian/samples-python-template/pull/32)
- [Bump SonarSource/sonarqube-scan-action from 6.0.0 to 7.0.0](https://github.com/augustocristian/samples-python-template/pull/31)
- [Bump actions/download-artifact from 6 to 7](https://github.com/augustocristian/samples-python-template/pull/30)
- [Bump actions/upload-artifact from 5 to 6](https://github.com/augustocristian/samples-python-template/pull/29)