### PR TITLE
Combined dependency updates (2026-03-09)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Download coverage reports
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
       - name: SonarQubeScan
         uses: SonarSource/sonarqube-scan-action@a31c9398be7ace6bbfaf30c0bd5d415f843d45e9 # V.6.0 lastest 05/10/2025
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,12 +35,12 @@ jobs:
         run: |
           pytest
       - name: Store coverage report
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-unit
           path: coverage.xml
       - name: Archive logs
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: test-logs
           path: logs/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "samples-python-template"
 version = "2024.0.0"
 dependencies = [
-    "setuptools==80.9.0",
+    "setuptools==82.0.0",
     "pytest==9.0.2",
     "pytest-cov==7.0.0",
     "flake8== 7.3.0",


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump setuptools from 80.9.0 to 82.0.0](https://github.com/augustocristian/samples-python-template/pull/37)
- [Bump actions/download-artifact from 7 to 8](https://github.com/augustocristian/samples-python-template/pull/36)
- [Bump actions/upload-artifact from 6 to 7](https://github.com/augustocristian/samples-python-template/pull/35)