### PR TITLE
Configure PyPI publishing (Trusted Publishing) — v2026.07.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,4 +50,4 @@ jobs:
           name: dist
           path: dist/
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@release/v1@ba38be9e461d3875417946c167d0b5f3d385a247

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,53 @@
+name: publish
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    name: "Build distribution"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Install Poetry
+        uses: snok/install-poetry@a783c322200f0519c7926aa6faa857c4e23e9263 # v1
+        with:
+          version: "2.4.0"
+      - name: Check tag matches project version
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          PROJECT_VERSION="$(poetry version --short)"
+          if [ "$TAG_VERSION" != "$PROJECT_VERSION" ]; then
+            echo "Release tag ($GITHUB_REF_NAME) does not match pyproject.toml version ($PROJECT_VERSION)"
+            exit 1
+          fi
+      - name: Build package
+        run: poetry build
+      - name: Store distribution artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    name: "Publish to PyPI"
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: pypi
+      url: https://pypi.org/project/samples-python-template/
+    permissions:
+      id-token: write # required for PyPI trusted publishing (OIDC)
+    steps:
+      - name: Download distribution artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: dist
+          path: dist/
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,8 @@ jobs:
           poetry run flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
       - name: Test with pytest
         run: poetry run pytest
+      - name: Build package
+        run: poetry build
       - name: Store coverage report
         uses: actions/upload-artifact@v7
         with:
@@ -46,6 +48,7 @@ jobs:
     name: SonarCloud
     runs-on: ubuntu-latest
     needs: build
+    if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
       - uses: actions/checkout@v7
         with:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Status](https://github.com/augustocristian/samples-python-template/actions/workflows/test.yml/badge.svg)](https://github.com/augustocristian/samples-python-template/actions)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=augustocristian_samples-python-template&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=augustocristian_samples-python-template)
+[![PyPI](https://img.shields.io/pypi/v/samples-python-template.svg)](https://pypi.org/project/samples-python-template/)
 
 # samples-python-template
 
@@ -8,7 +9,23 @@ Template project, includes:
 - Configuration of a python project, following the guideliness of HitChhiker's book [^1]
 - Aggregated test reports (pytest style)
 - SonarCloud static test (includes coverage results)
-- Publish the package/lib in PyPI’s (not yet available)
+- Publish the package/lib in PyPI's
+
+## Publishing to PyPI
+
+Publishing is handled by [.github/workflows/publish.yml](.github/workflows/publish.yml), which builds the package
+with Poetry and uploads it to PyPI using [Trusted Publishing](https://docs.pypi.org/trusted-publishers/) (OIDC) —
+no API token secret is stored in the repo.
+
+To release a new version:
+
+1. Bump `version` under `[project]` in [pyproject.toml](pyproject.toml).
+2. Commit and merge the version bump to `main`.
+3. Create a GitHub Release with tag `vX.Y.Z` matching the `pyproject.toml` version (e.g. `v2024.1.0`). Publishing the
+   release triggers the workflow.
+
+One-time setup (repo/PyPI admin only): on [pypi.org](https://pypi.org), add a Trusted Publisher for this project
+pointing at this GitHub repo, workflow file `publish.yml`, and environment `pypi`.
 
 See the general contribution policies and guidelines for *giis-uniovi* at
 [CONTRIBUTING.md](https://github.com/giis-uniovi/.github/blob/main/profile/CONTRIBUTING.md).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,11 +3,11 @@ requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-package-mode = false
+packages = [{ include = "sample" }]
 
 [project]
 name = "samples-python-template"
-version = "2024.0.0"
+version = "2026.07.0"
 dependencies = [
     "setuptools==82.0.1",
     "pytest==9.0.3",


### PR DESCRIPTION
Changes performed:

- Enable Poetry package-mode so `poetry build` produces an installable wheel/sdist for the `sample` package
- Add `.github/workflows/publish.yml`: on GitHub Release published, builds the package, checks the release tag matches `pyproject.toml`'s version, and publishes to PyPI via Trusted Publishing (OIDC) — no stored API token
- Add a `poetry build` sanity step to the existing test workflow so packaging issues surface on every PR
- Bump version to `2026.07.0` for the first release
- Update README with the publishing process and one-time Trusted Publisher setup note
