### PR TITLE
Combined dependency updates (2026-08-02)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -45,4 +45,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: Set up Python 3.12
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.12"
       - name: Install Poetry

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Build documentation
         run: poetry run sphinx-build -b html docs docs/_build/html -W --keep-going
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
         with:
           path: docs/_build/html
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: Set up Python 3.12
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.12"
       - name: Install Poetry

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,4 +54,4 @@ jobs:
           name: dist
           path: dist/
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,6 +58,6 @@ jobs:
       - name: Download coverage reports
         uses: actions/download-artifact@v8
       - name: SonarQubeScan
-        uses: SonarSource/sonarqube-scan-action@713881670b6b3676cda39549040e2d88c70d582e # V.6.0 lastest 05/10/2025
+        uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # V.6.0 lastest 05/10/2025
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: Set up Python 3.12
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.12"
       - name: Install Poetry


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump SonarSource/sonarqube-scan-action from 8.2.0 to 8.2.1](https://github.com/augustocristian/samples-python-template/pull/57)
- [Bump pypa/gh-action-pypi-publish from 1.14.1 to 1.14.2](https://github.com/augustocristian/samples-python-template/pull/56)
- [Bump actions/setup-python from 6 to 7](https://github.com/augustocristian/samples-python-template/pull/55)
- [Bump actions/deploy-pages from 4 to 5](https://github.com/augustocristian/samples-python-template/pull/54)
- [Bump actions/upload-pages-artifact from 4 to 5](https://github.com/augustocristian/samples-python-template/pull/53)